### PR TITLE
added scan tag for xml validation

### DIFF
--- a/channels.xsd
+++ b/channels.xsd
@@ -236,6 +236,12 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="scan">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="8"/>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="tag">
         <xs:restriction base="xs:string">
             <xs:maxLength value="8"/>
@@ -280,8 +286,8 @@
                 <xs:element name="power" type="power" default="low" minOccurs="0"/>
                 <xs:element name="name" type="xs:string" minOccurs="0"/>
                 <xs:element name="tag" type="tag" minOccurs="0"/>
+                <xs:element name="scan" type="scan" minOccurs="0"/>
                 <xs:element name="skip" type="xs:boolean" fixed="true" minOccurs="0"/>
-                <xs:any notNamespace="##local" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
             <xs:attribute name="name" type="memname" use="optional"/>
             <xs:attribute name="bank" type="bank" use="optional"/>


### PR DESCRIPTION
Notes: 
$ xmllint --schema channels.xsd channels.xml
channels.xsd:284: element any: Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}any': The attribute 'notNamespace' is not allowed.
WXS schema channels.xsd failed to compile
^^ removed the "notNamespace" line

added the scan option
<scan>select</scan>
